### PR TITLE
Invalidate URLSession to prevent memory leak

### DIFF
--- a/FunkyNetwork/Classes/NetworkCall.swift
+++ b/FunkyNetwork/Classes/NetworkCall.swift
@@ -59,6 +59,7 @@ open class NetworkCall {
             self.errorProperty.value = error as NSError?
             self.responseProperty.value = response
             self.dataProperty.value = data
+            session.finishTasksAndInvalidate()
         }
     }
     


### PR DESCRIPTION
Since every network call uses a new URLSession, it can be invalidated once the call is completed. If it is not invalidated, various objects are not released, due to a strong reference between the session and the cache.