### PR TITLE
Add support for passing in an existing URLSessionConfiguration

### DIFF
--- a/FunkyNetwork/Classes/NetworkCall.swift
+++ b/FunkyNetwork/Classes/NetworkCall.swift
@@ -53,7 +53,7 @@ open class NetworkCall {
     }
     
     open func fire() {
-        let session = URLSession(configuration: URLSessionConfiguration.default, delegate: nil, delegateQueue: OperationQueue.main)
+        let session = URLSession(configuration: configuration.urlConfiguration, delegate: nil, delegateQueue: OperationQueue.main)
         let request = self.mutableRequest()
         dataTaskProperty.value = session.dataTask(with: request as URLRequest) { (data, response, error) in
             self.errorProperty.value = error as NSError?

--- a/FunkyNetwork/Classes/ServerConfiguration.swift
+++ b/FunkyNetwork/Classes/ServerConfiguration.swift
@@ -14,6 +14,7 @@ public protocol ServerConfigurationProtocol {
     var scheme: String { get }
     var host: String { get }
     var apiBaseRoute: String? { get }
+    var urlConfiguration: URLSessionConfiguration { get set }
 }
 
 open class ServerConfiguration: ServerConfigurationProtocol {
@@ -21,11 +22,13 @@ open class ServerConfiguration: ServerConfigurationProtocol {
     public let scheme: String
     public let host: String
     public let apiBaseRoute: String?
-    
-    public init(shouldStub: Bool = false, scheme: String = "https", host: String, apiRoute: String?) {
+    public var urlConfiguration: URLSessionConfiguration
+
+    public init(shouldStub: Bool = false, scheme: String = "https", host: String, apiRoute: String?, urlConfiguration: URLSessionConfiguration = URLSessionConfiguration.default) {
         self.shouldStub = shouldStub
         self.scheme = scheme
         self.host = host
         self.apiBaseRoute = apiRoute
+        self.urlConfiguration = urlConfiguration
     }
 }


### PR DESCRIPTION
This allows a custom/existin URLSessionConfiguration to be passed in as part of the ServerConfiguration. Usecase is p.e. to allow Instabug to log network requests.